### PR TITLE
Fix array handling

### DIFF
--- a/check_http_json.rb
+++ b/check_http_json.rb
@@ -59,8 +59,7 @@ def hash_flatten(hash, delimiter, prefix = nil, flat = {})
     if hash.is_a? Array then
         hash.each_index do |index|
             newkey = index
-            newkey = nil if hash.length == 1
-            newkey = prefix if prefix
+            newkey = '%s%s%s' % [prefix, delimiter, newkey] if prefix
             val = hash[index]
             hash_flatten val, delimiter, newkey, flat
         end


### PR DESCRIPTION
This change fixes array handling, in our case and all scenarios we tested.  Previously, an array with multiple hashes was flattened and only the last hash values remained. After this change, all elements of the array are preserved.

As reported in #19 the following json string was incorrectly handled:

```
{"tests":[{"name":"valueAddGiftCard","time":1240,"valid":true},{"name":"chargeGiftCard","time":218,"valid":true},{"name":"lookupGiftCard","time":2454,"valid":true}]}
```

Now, we can address these values as `tests.0.name` = 'valueAddGiftCard' and `tests.0.time` = 1240 and so on.  We tested this will different combinations of hashes and arrays and everything we could think of.  It doesn't break things and it fixes what we were seeing.

Please let me know if you have any questions or concerns with this. Thanks for your consideration.
