### PR TITLE
Adding REGEX support for WARN and CRIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a plugin for Nagios that will parse JSON from an HTTP response. It is wr
 ## Usage
 
 ```
-Usage: ./check_http_json.rb -u <URI> -e <element> -w <warn> -c <crit>
+Usage: /usr/local/nagios/plugins/alphatrek/check_http_json.rb -u <URI> -e <element> -w <warn> -c <crit>
     -h, --help                       Help info.
     -v, --verbose                    Additional human output.
     -u, --uri URI                    Target URI. Incompatible with -f.
@@ -25,6 +25,9 @@ Usage: ./check_http_json.rb -u <URI> -e <element> -w <warn> -c <crit>
     -W, --result_warn STRING         Warning if element is [string]. -C is required.
     -U, --result_unknown STRING      Unknown if element is [string]. -C is required.
     -C, --result_crit STRING         Critical if element is [string]. -W is required.
+    -X, --result_warn_regex REGEX    Warning if element matches REGEX. -C is required.
+    -V, --result_unknown_regex REGEX Unknown if element matches REGEX. -C is required.
+    -D, --result_crit_regex REGEX    Critical if element matches REGEX. -W is required.
     -p, --perf ELEMENT               Output additional fields (performance metrics); comma-separated.
     -t, --timeout SECONDS            Wait before HTTP timeout.
 ```
@@ -36,12 +39,12 @@ If a simple result of either string or regular expression (`-r` or `-R`) is spec
 * A match is OK and anything else is CRIT.
 * The warn / crit thresholds will be ignored.
 
-If the warn and crit results (`-W` and `-C`) are specified:
+If the warn and crit results (`-W` and `-C`) or regular expressions (`-X` and `-D`) are specified:
 
 * A match is WARN or CRIT and anything else is OK.
 * The warn / crit thresholds will be ignored.
 
-Note that (`-r` or `-R`) and (`-W` and `-C`) are mutually exclusive.
+Note that (`-r` or `-R`), (`-W` and `-C`), and  (`-X` and `-D`) are mutually exclusive.
 
 Note also that the response must be pure JSON. Bad things happen if this isn't the case.
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Usage: ./check_http_json.rb -u <URI> -e <element> -w <warn> -c <crit>
     -W, --result_warn STRING         Warning if element is [string]. -C is required.
     -U, --result_unknown STRING      Unknown if element is [string]. -C is required.
     -C, --result_crit STRING         Critical if element is [string]. -W is required.
-    -X, --result_warn_regex REGEX    Warning if element matches REGEX. -C is required.
-    -V, --result_unknown_regex REGEX Unknown if element matches REGEX. -C is required.
-    -D, --result_crit_regex REGEX    Critical if element matches REGEX. -W is required.
+        --result_warn_regex REGEX    Warning if element matches REGEX. --result_crit_regex is required.
+        --result_unknown_regex REGEX Unknown if element matches REGEX. --result_crit_regex is required.
+        --result_crit_regex REGEX    Critical if element matches REGEX. --result_warn_regex is required.
     -p, --perf ELEMENT               Output additional fields (performance metrics); comma-separated.
     -t, --timeout SECONDS            Wait before HTTP timeout.
 ```
@@ -39,12 +39,12 @@ If a simple result of either string or regular expression (`-r` or `-R`) is spec
 * A match is OK and anything else is CRIT.
 * The warn / crit thresholds will be ignored.
 
-If the warn and crit results (`-W` and `-C`) or regular expressions (`-X` and `-D`) are specified:
+If the warn and crit results (`-W` and `-C`) or regular expressions (`--result_warn_regex` and `--result_crit_regex`) are specified:
 
 * A match is WARN or CRIT and anything else is OK.
 * The warn / crit thresholds will be ignored.
 
-Note that (`-r` or `-R`), (`-W` and `-C`), and  (`-X` and `-D`) are mutually exclusive.
+Note that (`-r` or `-R`), (`-W` and `-C`), and  (`--result_warn_regex` and `--result_crit_regex`) are mutually exclusive.
 
 Note also that the response must be pure JSON. Bad things happen if this isn't the case.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a plugin for Nagios that will parse JSON from an HTTP response. It is wr
 ## Usage
 
 ```
-Usage: /usr/local/nagios/plugins/alphatrek/check_http_json.rb -u <URI> -e <element> -w <warn> -c <crit>
+Usage: ./check_http_json.rb -u <URI> -e <element> -w <warn> -c <crit>
     -h, --help                       Help info.
     -v, --verbose                    Additional human output.
     -u, --uri URI                    Target URI. Incompatible with -f.

--- a/check_http_json.rb
+++ b/check_http_json.rb
@@ -362,17 +362,17 @@ def parse_args(options)
         end
 
         options[:result_regex_warn] = nil
-        opts.on('-X', '--result_warn_regex REGEX', 'Warning if element matches REGEX. -D is required.') do |x|
+        opts.on('--result_warn_regex REGEX', 'Warning if element matches REGEX. --result_crit_regex is required.') do |x|
             options[:result_regex_warn] = x
         end
 
         options[:result_regex_unknown] = nil
-        opts.on('-V', '--result_unknown_regex REGEX', 'Unknown if element matches REGEX. -D is required.') do |x|
+        opts.on('--result_unknown_regex REGEX', 'Unknown if element matches REGEX. --result_crit_regex is required.') do |x|
             options[:result_regex_unknown] = x
         end
 
         options[:result_regex_crit] = nil
-        opts.on('-D', '--result_crit_regex REGEX', 'Critical if element matches REGEX. -X is required.') do |x|
+        opts.on('--result_crit_regex REGEX', 'Critical if element matches REGEX. --result_warn_regex is required.') do |x|
             options[:result_regex_crit] = x
         end
 

--- a/check_http_json.rb
+++ b/check_http_json.rb
@@ -361,6 +361,21 @@ def parse_args(options)
             options[:result_string_crit] = x
         end
 
+        options[:result_regex_warn] = nil
+        opts.on('-X', '--result_warn_regex REGEX', 'Warning if element matches REGEX. -D is required.') do |x|
+            options[:result_regex_warn] = x
+        end
+
+        options[:result_regex_unknown] = nil
+        opts.on('-V', '--result_unknown_regex REGEX', 'Unknown if element matches REGEX. -D is required.') do |x|
+            options[:result_regex_unknown] = x
+        end
+
+        options[:result_regex_crit] = nil
+        opts.on('-D', '--result_crit_regex REGEX', 'Critical if element matches REGEX. -X is required.') do |x|
+            options[:result_regex_crit] = x
+        end
+
         options[:perf] = nil
         opts.on('-p', '--perf ELEMENT', 'Output additional fields (performance metrics); comma-separated.') do |x|
             options[:perf] = x.split(',')
@@ -405,7 +420,7 @@ def sanity_check(options)
         error_msg.push('Delimiter must be a single character.')
     end
 
-    if not ((options[:result_string] or options[:result_regex]) or (options[:warn] and options[:crit]) or (options[:result_string_warn] and options[:result_string_crit])) then
+    if not ((options[:result_string] or options[:result_regex]) or (options[:warn] and options[:crit]) or (options[:result_string_warn] and options[:result_string_crit]) or (options[:result_regex_warn] and options[:result_regex_crit])) then
         error_msg.push('Must specify an expected result OR the warn and crit thresholds.')
     end
 
@@ -497,13 +512,15 @@ end
 
 # build ok message
 if options[:result_string]
-    Nagios.ok = '%s does match %s' % [element_message_name, options[:result_string]]
+    Nagios.ok = '%s does match \'%s\'' % [element_message_name, options[:result_string]]
 elsif options[:result_regex]
-    Nagios.ok = "'%s' (regex) does match %s" % [element_message_name, options[:result_regex]]
+    Nagios.ok = '\'%s\' (regex) does match \'%s\'' % [element_message_name, options[:result_regex]]
 end
 
 if options[:result_string_warn] && options[:result_string_crit]
-    Nagios.ok = '%s does not match %s or %s' % [element_message_name, options[:result_string_warn], options[:result_string_crit]]
+    Nagios.ok = '%s does not match \'%s\' or \'%s\'' % [element_message_name, options[:result_string_warn], options[:result_string_crit]]
+elsif options[:result_regex_warn] && options[:result_regex_crit]
+     Nagios.ok = '%s does not match (REGEX) \'%s\' or \'%s\'' % [element_message_name, options[:result_regex_warn], options[:result_regex_crit]]
 end
 
 if options[:crit]
@@ -553,6 +570,25 @@ options[:element].each do |element|
         # check next element
         next
     end
+    
+    # If we're specifying critical & warning regex...
+    if options[:result_regex_warn] && options[:result_regex_crit]
+        say(options[:v], '%s should not match against \'%s\' (REGEX), else CRIT' % [element, options[:result_regex_crit]])
+        say(options[:v], '%s should not match against \'%s\' (REGEX), else WARN' % [element, options[:result_regex_warn]])
+        msg = '%s matches %s' % [element, element_value]
+
+        case element_value.to_s
+        when Regexp.new(options[:result_regex_crit].to_s)
+            Nagios.critical = msg
+        when Regexp.new(options[:result_regex_warn].to_s)
+            Nagios.warning = msg
+        when Regexp.new(options[:result_regex_unknown].to_s)
+            Nagios.unknown = msg
+        end
+        # check next element
+        next
+    end
+
 
     # If we're dealing with threshold values...
 


### PR DESCRIPTION
I have an API that I check which returns multiple different status results that I want to consider WARN and CRIT. I figured that the easiest way to add this capability was to add Regular Expression support for `-W` and `-X`, since that allows for much more powerful usage.

Since the uppercase and lowercase letters were already used, I used the next letter in the alphabet for each argument. That can certainly be changed if needed.