### PR TITLE
move perf_splitter position in help output

### DIFF
--- a/check_http_json.rb
+++ b/check_http_json.rb
@@ -361,14 +361,14 @@ def parse_args(options)
             options[:result_string_crit] = x
         end
 
-        options[:perf_splitter] = ','
-        opts.on('--perf_splitter CHARACTER', 'Specify an alternative character to split performance keys.') do |x|
-            options[:perf_splitter] = x
-        end
-
         options[:perf] = nil
         opts.on('-p', '--perf ELEMENT', 'Output additional fields (performance metrics); comma-separated.') do |x|
             options[:perf] = x
+        end
+
+        options[:perf_splitter] = ','
+        opts.on('--perf_splitter CHARACTER', 'Specify an alternative character to split performance keys.') do |x|
+            options[:perf_splitter] = x
         end
 
         options[:timeout] = 5


### PR DESCRIPTION
Moved the position of `perf_splitter` so that it appears under `perf` (as in the README).