### PR TITLE
Add parameter to specify the default return code on non-200 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Usage: ./check_http_json.rb -u <URI> -e <element> -w <warn> -c <crit>
         --pass PASSWORD              HTTP basic authentication password.
         --headers HEADERS            Comma-separated list of HTTP headers to include (ex. HOST:somehost,AUTH:letmein).
         --status_level STRING        Comma-separated list of HTTP status codes and their associated Nagios alert levels (ex. 301:1,404:2).
+        --status_level_default VALUE The default return code for unexpected HTTP status codes. Defaults to 1.
     -f, --file PATH                  Target file. Incompatible with -u.
     -e, --element ELEMENT...         Desired element (ex. foo=>bar=>ish is foo.bar.ish). Repeatable argument.
     -E, --element_regex REGEX        Desired element expressed as regular expression.

--- a/check_http_json.rb
+++ b/check_http_json.rb
@@ -214,8 +214,7 @@ def uri_target(options)
 
     # We must get a 200 response; if not, the user might want to know.
     if not response.code.to_i == 200 then
-        # WARN by default.
-        level = 1
+        level = options[:status_level_default]
         if options[:status_level] then
             options[:status_level].each do |s|
                 k,v = s.split(':')
@@ -299,6 +298,11 @@ def parse_args(options)
         options[:status_level] = nil
         opts.on('--status_level STRING', 'Comma-separated list of HTTP status codes and their associated Nagios alert levels (ex. 301:1,404:2).') do |x|
             options[:status_level] = x.split(',')
+        end
+
+        options[:status_level_default] = 1
+        opts.on('--status_level_default INT', 'The default return code for not-expected http status codes. Defaults to 1.') do |x|
+            options[:status_level_default] = x.to_i
         end
 
         options[:file] = nil

--- a/check_http_json.rb
+++ b/check_http_json.rb
@@ -301,7 +301,7 @@ def parse_args(options)
         end
 
         options[:status_level_default] = 1
-        opts.on('--status_level_default INT', 'The default return code for not-expected http status codes. Defaults to 1.') do |x|
+        opts.on('--status_level_default VALUE', 'The default return code for unexpected HTTP status codes. Defaults to 1.') do |x|
             options[:status_level_default] = x.to_i
         end
 


### PR DESCRIPTION
In case you always want critical when the response is unexpected (probably used in combination with `--status_level`)