### PR TITLE
allow non 200 HTTP return code to be OK, fixes #48

### DIFF
--- a/check_http_json.rb
+++ b/check_http_json.rb
@@ -224,8 +224,10 @@ def uri_target(options)
                 end
             end
         end
-        msg = 'Received HTTP code %s instead of 200.' % [response.code]
-        Nagios.do_exit(level.to_i, msg)
+        if not level == 0 then
+            msg = 'Received HTTP code %s instead of 200.' % [response.code]
+            Nagios.do_exit(level.to_i, msg)
+        end
     end
 
     say(options[:v], "RESPONSE:\n---\n%s\n---" % [response.body])


### PR DESCRIPTION
I'm using it to detect if my vault nodes are unsealed.
Standby nodes in HA mode return 429 instead of 200, which is intended by vault (https://github.com/hashicorp/vault/pull/2850)

The default behavior stops validating the JSON output as soon as `--status_level 429:0` is specified:

```
$ check_http_json.rb -u http://127.0.0.1:8200/v1/sys/health -e sealed -r false --status_level 429:0
OK: sealed does match 'false'
```