### PR TITLE
Clear out that you can use Nagios threshold ranges format (not only integer) for warning and critical parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Usage: ./check_http_json.rb -u <URI> -e <element> -w <warn> -c <crit>
     -E, --element_regex REGEX        Desired element expressed as regular expression.
         --element_regex_global       Check all occurring matches. -E is required.
     -d, --delimiter CHARACTER        Element delimiter (default is period).
-    -w, --warn VALUE                 Warning threshold (integer).
-    -c, --crit VALUE                 Critical threshold (integer).
+    -w, --warn VALUE                 Warning threshold (integer or Nagios threshold ranges format).
+    -c, --crit VALUE                 Critical threshold (integer or Nagios threshold ranges format).
     -r, --result STRING              Expected string result. No need for -w or -c.
     -R, --result_regex REGEX         Expected string result expressed as regular expression. No need for -w or -c.
     -W, --result_warn STRING         Warning if element is [string]. -C is required.

--- a/check_http_json.rb
+++ b/check_http_json.rb
@@ -332,12 +332,12 @@ def parse_args(options)
         end
 
         options[:warn] = nil
-        opts.on('-w', '--warn VALUE', 'Warning threshold (integer).') do |x|
+        opts.on('-w', '--warn VALUE', 'Warning threshold (integer or Nagios threshold ranges format).') do |x|
             options[:warn] = x.to_s
         end
 
         options[:crit] = nil
-        opts.on('-c', '--crit VALUE', 'Critical threshold (integer).') do |x|
+        opts.on('-c', '--crit VALUE', 'Critical threshold (integer or Nagios threshold ranges format).') do |x|
             options[:crit] = x.to_s
         end
 


### PR DESCRIPTION
In the help/usage output of the command, warning and critical parameters are described the way that only integer can be used.
But in readme, it is mentioned that also Nagios threshold ranges are supported. So provide this information also in the command help/usage output.