### PR TITLE
[bug] cast to string; closes #55

### DIFF
--- a/check_http_json.rb
+++ b/check_http_json.rb
@@ -684,7 +684,7 @@ options[:element].each do |element|
     # If we're dealing with threshold values...
 
     # Numbahs only, brah.
-    if element_value =~ /\D/
+    if element_value.to_s =~ /\D/
         say(options[:v], 'The value of %s contains non-numeric characters.' % [element])
         Nagios.unknown = 'Return value syntax failure.'
         next


### PR DESCRIPTION
Cast to string in order to avoid potential type error (thanks @DanHosier).